### PR TITLE
Change chat text submission to Ctrl+Enter

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,9 +129,9 @@ export default function Home() {
   //prevent empty submissions
   const handleEnter = useCallback(
     (e: any) => {
-      if (e.key === 'Enter' && query) {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)&& query) {
         handleSubmit(e);
-      } else if (e.key == 'Enter') {
+      }else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
       }
     },


### PR DESCRIPTION
# Summary
This PR changes the chat text submission to use Ctrl+Enter instead of Enter, improving the user experience for those who require keyboard conversions.


# Description
Currently, the chat text is submitted by pressing the Enter key, which can be problematic for users who need to convert their input in languages that require keyboard conversions. 
![ezgif-4-e75b039332](https://user-images.githubusercontent.com/19320112/229569315-a6cc2330-e3de-4451-9047-00ea8c48767b.gif)

To address this issue, I have changed the chat text submission to use Ctrl+Enter, similar to the OpenAI Chat UI and Slack.


Lastly, I would like to express my gratitude to the creator of this wonderful repository. Thank you!