### PR TITLE
fix: comment in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=
 
-# Update these with your Supabase details from your project settings > API and dashboard settings
+# Update these with your Pinecone details from your project settings > API and dashboard settings
 PINECONE_API_KEY=
 PINECONE_ENVIRONMENT=
 PINECONE_INDEX_NAME=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 OPENAI_API_KEY=
 
-# Update these with your Pinecone details from your project settings > API and dashboard settings
+# Update these with your Pinecone details from your project settings > API Keys
 PINECONE_API_KEY=
 PINECONE_ENVIRONMENT=
+
+# Update this with your pinecone Index Name
 PINECONE_INDEX_NAME=


### PR DESCRIPTION
There was a confusing comment in example.env telling people to replace the credentials with Supabase details