### PR TITLE
Update README.md - add the 1536 dimension number at the start so you don't get bit later. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ PINECONE_INDEX_NAME=
 ```
 
 - Visit [openai](https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key) to retrieve API keys and insert into your `.env` file.
-- Visit [pinecone](https://pinecone.io/) to create and retrieve your API keys, and also retrieve your environment and index name from the dashboard.
+- Visit [pinecone](https://pinecone.io/) create an index (same as PINECONE_INDEX_NAME in the .env file), set the dimension to 1536, you will then be able to retrieve the environment once the index is created. 
 
 4. In the `config` folder, replace the `PINECONE_NAME_SPACE` with a `namespace` where you'd like to store your embeddings on Pinecone when you run `npm run ingest`. This namespace will later be used for queries and retrieval.
 


### PR DESCRIPTION
A just a small edit on the getting started steps. I went ahead and blindly created an index in pinecone not knowing what I should set the dimensions to, so I arbitrarily put in a number, which later came back to bite me because it wasn't in line with OpenAI's 1536. I only found this out after it failed ingestion. If I had known to start with 1536 from the start, I could have avoided this. 

I know you mention this as a debug step in the bottom, but placing it right at the start could avoid this issue in the first place.