### PR TITLE
Solve Issue@470 by removing pinecone_environment var from connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,5 @@ OPENAI_API_KEY=
 
 # Update these with your pinecone details from your dashboard. 
 # PINECONE_INDEX_NAME is in the indexes tab under "index name" in blue
-# PINECONE_ENVIRONMENT is in indexes tab under "Environment". Example: "us-east1-gcp"
 PINECONE_API_KEY=  
-PINECONE_ENVIRONMENT=
 PINECONE_INDEX_NAME= 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ After installation, you should now see a `node_modules` folder.
 OPENAI_API_KEY=
 
 PINECONE_API_KEY=
-PINECONE_ENVIRONMENT=
 
 PINECONE_INDEX_NAME=
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
-    "@pinecone-database/pinecone": "1.1.0",
+    "@pinecone-database/pinecone": "3.0.2",
     "@radix-ui/react-accordion": "^1.1.1",
     "clsx": "^1.2.1",
     "dotenv": "^16.0.3",

--- a/utils/pinecone-client.ts
+++ b/utils/pinecone-client.ts
@@ -1,13 +1,12 @@
 import { Pinecone } from '@pinecone-database/pinecone';
 
-if (!process.env.PINECONE_ENVIRONMENT || !process.env.PINECONE_API_KEY) {
-  throw new Error('Pinecone environment or api key vars missing');
+if (!process.env.PINECONE_API_KEY) {
+  throw new Error('Pinecone api key var missing');
 }
 
 async function initPinecone() {
   try {
     const pinecone = new Pinecone({
-      environment: process.env.PINECONE_ENVIRONMENT ?? '', //this is in the dashboard
       apiKey: process.env.PINECONE_API_KEY ?? '',
     });
 


### PR DESCRIPTION
This pull request is to solve https://github.com/mayooear/gpt4-pdf-chatbot-langchain/issues/470. According to the [docs](https://docs.pinecone.io/guides/indexes/migrate-a-pod-based-index-to-serverless#create-a-serverless-index) and the [community](https://community.pinecone.io/t/where-to-find-my-environment-details/4920) on pinecone, it doesn't need the ENVIRONMENT variable to connect anymore. In addition, this pr upgrade pinecone-database/pinecone from 1.1.0 to 3.0.2.

Plz correct me if you find anything wrong. Thanks😊